### PR TITLE
Removed link to deleted docs/workflow.org.

### DIFF
--- a/docs/index.org
+++ b/docs/index.org
@@ -58,7 +58,8 @@ d s= (or =C-h d s=).
 - Other ways to support Doom Emacs
 - Special thanks
 
-** TODO [[file:workflow.org][Workflow Tips, Tricks & Tutorials]]
+** TODO Workflow Tips, Tricks & Tutorials
+Will be made available on the discourse.
 
 ** [[file:modules.org][Module Appendix]]
 


### PR DESCRIPTION
As stated in the delete-commit `workflow.org` will be moved to the discourse.